### PR TITLE
Fixed root node removal in `remove_tree`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ smallvec = "1.7"
 ndshape = "0.3"
 
 # The default choice of VectorKey.
-glam = { version = "0.25", optional = true }
+glam = { version = "0.29", optional = true }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -764,7 +764,7 @@ where
         coordinates: V,
         mut consumer: impl FnMut(NodeKey<V>, T),
     ) {
-        self.unlink_child(relation);
+        self.unlink_child(relation, coordinates);
 
         let mut to_remove = SmallVec::<[(NodePtr, V); 32]>::new();
         to_remove.push((relation.child, coordinates));
@@ -797,12 +797,13 @@ where
         }
     }
 
-    fn unlink_child(&mut self, relation: &ChildRelation<V>) {
+    fn unlink_child(&mut self, relation: &ChildRelation<V>, coordinates: V) {
         if let Some(parent) = relation.parent.as_ref() {
-            self.root_nodes
-                .remove(&NodeKey::new(relation.child.level + 1, parent.coordinates));
             self.allocator_mut(parent.ptr.level)
                 .unlink_child(parent.ptr.alloc_ptr, parent.child_index);
+        } else {
+            self.root_nodes
+                .remove(&NodeKey::new(relation.child.level, coordinates));
         }
     }
 


### PR DESCRIPTION
This is a quick fix I made to `unlink_child` to attempt to fix https://github.com/bonsairobo/grid-tree-rs/issues/8, this seems to work well in my use case, although I'm not sure I fully understand the allocator system, so maybe there is something missing and some nodes are not being freed. LMK if you have some time to validate if this is correct, I can also add a test if preferred!

I also bumped glam to 0.29 as it was conflicting with the version bevy uses